### PR TITLE
Removed `isPartOf`

### DIFF
--- a/items/Picnic_Day_1909.jsonld.json
+++ b/items/Picnic_Day_1909.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1909_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1910.jsonld.json
+++ b/items/Picnic_Day_1910.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1910_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1912.jsonld.json
+++ b/items/Picnic_Day_1912.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1912_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1913.jsonld.json
+++ b/items/Picnic_Day_1913.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1913_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1915.jsonld.json
+++ b/items/Picnic_Day_1915.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1915_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1916.jsonld.json
+++ b/items/Picnic_Day_1916.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1916_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1917.jsonld.json
+++ b/items/Picnic_Day_1917.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1917_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1918.jsonld.json
+++ b/items/Picnic_Day_1918.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1918_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1919.jsonld.json
+++ b/items/Picnic_Day_1919.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1919_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1920.jsonld.json
+++ b/items/Picnic_Day_1920.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1920_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1922.jsonld.json
+++ b/items/Picnic_Day_1922.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1922_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1923.jsonld.json
+++ b/items/Picnic_Day_1923.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1923_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1925.jsonld.json
+++ b/items/Picnic_Day_1925.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1925_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1926.jsonld.json
+++ b/items/Picnic_Day_1926.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1926_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1927.jsonld.json
+++ b/items/Picnic_Day_1927.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1927_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1928.jsonld.json
+++ b/items/Picnic_Day_1928.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1928_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1929.jsonld.json
+++ b/items/Picnic_Day_1929.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1929_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1930.jsonld.json
+++ b/items/Picnic_Day_1930.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1930_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1931.jsonld.json
+++ b/items/Picnic_Day_1931.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1931_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1932.jsonld.json
+++ b/items/Picnic_Day_1932.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1932_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1933.jsonld.json
+++ b/items/Picnic_Day_1933.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1933_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1934.jsonld.json
+++ b/items/Picnic_Day_1934.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1934_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1935.jsonld.json
+++ b/items/Picnic_Day_1935.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1935_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1936.jsonld.json
+++ b/items/Picnic_Day_1936.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1936_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1937.jsonld.json
+++ b/items/Picnic_Day_1937.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1937_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1939.jsonld.json
+++ b/items/Picnic_Day_1939.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1939_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1940.jsonld.json
+++ b/items/Picnic_Day_1940.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1940_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1941.jsonld.json
+++ b/items/Picnic_Day_1941.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1941_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1942.jsonld.json
+++ b/items/Picnic_Day_1942.jsonld.json
@@ -34,9 +34,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1942_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1946.jsonld.json
+++ b/items/Picnic_Day_1946.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1946_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1947.jsonld.json
+++ b/items/Picnic_Day_1947.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1947_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1948.jsonld.json
+++ b/items/Picnic_Day_1948.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1948_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1949.jsonld.json
+++ b/items/Picnic_Day_1949.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1949_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1950.jsonld.json
+++ b/items/Picnic_Day_1950.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1950_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1951.jsonld.json
+++ b/items/Picnic_Day_1951.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1951_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1952.jsonld.json
+++ b/items/Picnic_Day_1952.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1952_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1953.jsonld.json
+++ b/items/Picnic_Day_1953.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1953_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1954.jsonld.json
+++ b/items/Picnic_Day_1954.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1954_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1955.jsonld.json
+++ b/items/Picnic_Day_1955.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1955_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1956.jsonld.json
+++ b/items/Picnic_Day_1956.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1956_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1957.jsonld.json
+++ b/items/Picnic_Day_1957.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1957_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1958.jsonld.json
+++ b/items/Picnic_Day_1958.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1958_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1959.jsonld.json
+++ b/items/Picnic_Day_1959.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1959_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1960.jsonld.json
+++ b/items/Picnic_Day_1960.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1960_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1961.jsonld.json
+++ b/items/Picnic_Day_1961.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1961_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1962.jsonld.json
+++ b/items/Picnic_Day_1962.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1962_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1963.jsonld.json
+++ b/items/Picnic_Day_1963.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1963_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1964.jsonld.json
+++ b/items/Picnic_Day_1964.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1964_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1965.jsonld.json
+++ b/items/Picnic_Day_1965.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1965_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1966.jsonld.json
+++ b/items/Picnic_Day_1966.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1966_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1967.jsonld.json
+++ b/items/Picnic_Day_1967.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1967_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1968.jsonld.json
+++ b/items/Picnic_Day_1968.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1968_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1969.jsonld.json
+++ b/items/Picnic_Day_1969.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1969_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1970.jsonld.json
+++ b/items/Picnic_Day_1970.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1970_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1971.jsonld.json
+++ b/items/Picnic_Day_1971.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1971_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1972.jsonld.json
+++ b/items/Picnic_Day_1972.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1972_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1973.jsonld.json
+++ b/items/Picnic_Day_1973.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1973_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1974.jsonld.json
+++ b/items/Picnic_Day_1974.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1974_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1975.jsonld.json
+++ b/items/Picnic_Day_1975.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/UCD_19750419-00.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://search.library.ucdavis.edu/permalink/01UCD_INST/13iosf5/alma990007983940403126"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1976.jsonld.json
+++ b/items/Picnic_Day_1976.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/UCD_19760424-00.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://search.library.ucdavis.edu/permalink/01UCD_INST/13iosf5/alma990007983940403126"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1978.jsonld.json
+++ b/items/Picnic_Day_1978.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/UCD_19780422-00.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://search.library.ucdavis.edu/permalink/01UCD_INST/13iosf5/alma990007983940403126"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1979.jsonld.json
+++ b/items/Picnic_Day_1979.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/UCD_19790421-00.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://search.library.ucdavis.edu/permalink/01UCD_INST/13iosf5/alma990007983940403126"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1980.jsonld.json
+++ b/items/Picnic_Day_1980.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/UCD_19800419-00.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://search.library.ucdavis.edu/permalink/01UCD_INST/13iosf5/alma990007983940403126"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1981.jsonld.json
+++ b/items/Picnic_Day_1981.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/UCD_19810425-00.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://search.library.ucdavis.edu/permalink/01UCD_INST/13iosf5/alma990007983940403126"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1982.jsonld.json
+++ b/items/Picnic_Day_1982.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/UCD_19820417-00.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://search.library.ucdavis.edu/permalink/01UCD_INST/13iosf5/alma990007983940403126"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1983.jsonld.json
+++ b/items/Picnic_Day_1983.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/UCD_19830416-00.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://search.library.ucdavis.edu/permalink/01UCD_INST/13iosf5/alma990007983940403126"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1984.jsonld.json
+++ b/items/Picnic_Day_1984.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1984_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1985.jsonld.json
+++ b/items/Picnic_Day_1985.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1985_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1986.jsonld.json
+++ b/items/Picnic_Day_1986.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/UCD_19860412-00.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://search.library.ucdavis.edu/permalink/01UCD_INST/13iosf5/alma990007983940403126"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1987.jsonld.json
+++ b/items/Picnic_Day_1987.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1987_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1988.jsonld.json
+++ b/items/Picnic_Day_1988.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/UCD_19880416-00.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://search.library.ucdavis.edu/permalink/01UCD_INST/13iosf5/alma990007983940403126"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1989.jsonld.json
+++ b/items/Picnic_Day_1989.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/UCD_19890414-00.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://search.library.ucdavis.edu/permalink/01UCD_INST/13iosf5/alma990007983940403126"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1990.jsonld.json
+++ b/items/Picnic_Day_1990.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/UCD_19900421-00.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://search.library.ucdavis.edu/permalink/01UCD_INST/13iosf5/alma990007983940403126"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1991.jsonld.json
+++ b/items/Picnic_Day_1991.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/UCD_19910419-00.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://search.library.ucdavis.edu/permalink/01UCD_INST/13iosf5/alma990007983940403126"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1992.jsonld.json
+++ b/items/Picnic_Day_1992.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/UCD_19920410-00.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://search.library.ucdavis.edu/permalink/01UCD_INST/13iosf5/alma990007983940403126"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1993.jsonld.json
+++ b/items/Picnic_Day_1993.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/UCD_19930416-00.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://search.library.ucdavis.edu/permalink/01UCD_INST/13iosf5/alma990007983940403126"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1994.jsonld.json
+++ b/items/Picnic_Day_1994.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/UCD_19940415-00.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://search.library.ucdavis.edu/permalink/01UCD_INST/13iosf5/alma990007983940403126"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1995.jsonld.json
+++ b/items/Picnic_Day_1995.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/UCD_19950421-00.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://search.library.ucdavis.edu/permalink/01UCD_INST/13iosf5/alma990007983940403126"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1996.jsonld.json
+++ b/items/Picnic_Day_1996.jsonld.json
@@ -34,9 +34,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1996_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1997.jsonld.json
+++ b/items/Picnic_Day_1997.jsonld.json
@@ -34,9 +34,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1997_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1998.jsonld.json
+++ b/items/Picnic_Day_1998.jsonld.json
@@ -34,9 +34,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_1998_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_1999.jsonld.json
+++ b/items/Picnic_Day_1999.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/UCD_19990416-00.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://search.library.ucdavis.edu/permalink/01UCD_INST/13iosf5/alma990007983940403126"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_2000.jsonld.json
+++ b/items/Picnic_Day_2000.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/UCD_20000414-00.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://search.library.ucdavis.edu/permalink/01UCD_INST/13iosf5/alma990007983940403126"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_2001.jsonld.json
+++ b/items/Picnic_Day_2001.jsonld.json
@@ -34,9 +34,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_program_2001-00.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_2002.jsonld.json
+++ b/items/Picnic_Day_2002.jsonld.json
@@ -34,9 +34,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_2002_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_2003.jsonld.json
+++ b/items/Picnic_Day_2003.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/UCD_20030411-00.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://search.library.ucdavis.edu/permalink/01UCD_INST/13iosf5/alma990007983940403126"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_2004.jsonld.json
+++ b/items/Picnic_Day_2004.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/UCD_20040416-00.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://search.library.ucdavis.edu/permalink/01UCD_INST/13iosf5/alma990007983940403126"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_2005.jsonld.json
+++ b/items/Picnic_Day_2005.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/UCD_20050415-00.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://search.library.ucdavis.edu/permalink/01UCD_INST/13iosf5/alma990007983940403126"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_2006.jsonld.json
+++ b/items/Picnic_Day_2006.jsonld.json
@@ -34,9 +34,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_2006_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_2007.jsonld.json
+++ b/items/Picnic_Day_2007.jsonld.json
@@ -34,9 +34,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_2007_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_2008.jsonld.json
+++ b/items/Picnic_Day_2008.jsonld.json
@@ -34,9 +34,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_2008_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_2009.jsonld.json
+++ b/items/Picnic_Day_2009.jsonld.json
@@ -34,9 +34,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_2009_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_2010.jsonld.json
+++ b/items/Picnic_Day_2010.jsonld.json
@@ -34,9 +34,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_2010_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_2011.jsonld.json
+++ b/items/Picnic_Day_2011.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_2011_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_2012.jsonld.json
+++ b/items/Picnic_Day_2012.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_2012_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_2013.jsonld.json
+++ b/items/Picnic_Day_2013.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_2013_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_2014.jsonld.json
+++ b/items/Picnic_Day_2014.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_2014_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_2015.jsonld.json
+++ b/items/Picnic_Day_2015.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_2015_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_2016.jsonld.json
+++ b/items/Picnic_Day_2016.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_2016_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_2017.jsonld.json
+++ b/items/Picnic_Day_2017.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_2017_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_2018.jsonld.json
+++ b/items/Picnic_Day_2018.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_2018_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },

--- a/items/Picnic_Day_2019.jsonld.json
+++ b/items/Picnic_Day_2019.jsonld.json
@@ -37,9 +37,6 @@
   "schema:image": {
     "@id": "@base:/media/Picnic_Day_2019_001.jpg"
   },
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/kt3h4nc8mz/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/InC-NC/1.0/"
   },


### PR DESCRIPTION
   To remove 'isPartOf` from all the items.

```bash
     for i in *.json; do
         cp $i tmp.json;
         jq 'del(.. | .["schema:isPartOf"]?)' tmp.json > $i;
     done ;
     rm tmp.json
```
